### PR TITLE
Remove valid device orientation check from setSupportedDeviceOrientations

### DIFF
--- a/Source/UI/NBUViewController.m
+++ b/Source/UI/NBUViewController.m
@@ -58,11 +58,6 @@
 
 #pragma mark - Interface orientations
 
-- (void)setSupportedInterfaceOrientations:(UIInterfaceOrientationMask)supportedInterfaceOrientations
-{
-    _supportedInterfaceOrientations = supportedInterfaceOrientations;
-}
-
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations
 {
     if (_supportedInterfaceOrientations == 0)


### PR DESCRIPTION
This check enforces that the method's argument is a single device orientation,
but we want to pass in a mask that includes multiple device orientations.
