### PR TITLE
RKOrderedDictionary NSInvalidArgumentException

### DIFF
--- a/Library/RestKit Support/RKOrderedDictionary.m
+++ b/Library/RestKit Support/RKOrderedDictionary.m
@@ -52,7 +52,7 @@ NSString *RKDescriptionForObject(NSObject *object, id locale, NSUInteger indent)
 
 - (id)initWithCapacity:(NSUInteger)capacity
 {
-    self = [super initWithCapacity:capacity];
+    self = (capacity > 0) ? [super initWithCapacity:capacity] : [super init];
     if (self != nil)
     {
         dictionary = [[NSMutableDictionary alloc] initWithCapacity:capacity];


### PR DESCRIPTION
It happens from [`[RKOrderedDictionary dictionary]`](https://github.com/CyberAgent/iOS-NBUImagePicker/blob/master/Source/Camera/NBUCameraView.m#L559) that passes 0 to `[RKOrderedDictionary initWithCapacity:]` at [RKOrderedDictionary.m line 55](https://github.com/CyberAgent/iOS-NBUKit/blob/master/Library/RestKit%20Support/RKOrderedDictionary.m#L55).

This causes a runtime error on devices, but works fine on the simulator.

> **\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '**\* -[NSMutableDictionary initWithCapacity:]: method only defined for abstract class.  Define -[RKOrderedDictionary initWithCapacity:]!'

I didn't encounter the warning mentioned at https://github.com/CyberAgent/iOS-NBUKit/commit/41a54100a69bb6635384c95421b358e79a1412d8. Could it possibly use `self = [super init]` instead?
